### PR TITLE
Removing Lunar Commander Role

### DIFF
--- a/src/utils/registerCommands.ts
+++ b/src/utils/registerCommands.ts
@@ -6,19 +6,6 @@ import { clientId, token } from "../../config.json";
 import { commandFiles } from "./commandFiles";
 
 export const registerCommands = async (guild: Guild) => {
-  // Check if an existing lunar commander role exists in the server
-  const existingLunarCommanderRole = guild.roles.cache.find(
-    (role) => role.name === "Lunar Commander"
-  );
-
-  // If no such role exists, create it
-  const lunarCommanderRole = existingLunarCommanderRole
-    ? existingLunarCommanderRole
-    : await guild.roles.create({
-        name: "Lunar Commander",
-        color: "BLUE",
-        reason: "Managing the lunar assistant.",
-      });
 
   // get the list of new commands
   const newCommands = commandFiles.map((file) => {
@@ -35,23 +22,6 @@ export const registerCommands = async (guild: Guild) => {
   });
 
   console.log(`Successfully registered application commands for ${guild.name}`);
-
-  // now update the permissions to allow for lunar commanders to configure the lunar assistant
-  const permissions = [
-    {
-      id: lunarCommanderRole.id,
-      type: "ROLE" as const,
-      permission: true,
-    },
-  ];
-
-  const registeredCommands = await guild.commands.fetch();
-
-  // get the configured command
-  const configureCommand = registeredCommands.find((command) => {
-    return command.name == "lunar-configure";
-  });
-
-  // add the lunar command permission
-  await configureCommand!.permissions.add({ permissions });
 };
+
+


### PR DESCRIPTION
Due to the new Discord Permission system, it is no longer possible to achieve the functionality desired for the role.

For more info on this, click [here](https://discord.com/blog/slash-commands-permissions-discord-apps-bots).